### PR TITLE
pktgen: fix the possible range for the -O option

### DIFF
--- a/src/pktgen.c
+++ b/src/pktgen.c
@@ -32,6 +32,7 @@
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
 #include <linux/sockios.h>
+#include <sys/sysinfo.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/ethernet.h>
@@ -1109,7 +1110,8 @@ static int parse_main_args(int argc, char *argv[], struct opts *opts)
 			}
 			break;
 		case 'O':
-			if (str_to_int(optarg, 1, INT_MAX, &opts->cpu_offset) != 0) {
+			if (str_to_int(optarg, 0, get_nprocs() - 1,
+				       &opts->cpu_offset) != 0) {
 				log_error("invalid CPU offset\n");
 				return -1;
 			}


### PR DESCRIPTION
The -O option lets us to choose the CPU core to start "affining" with, but it
was wrongly checked against the [1, ∞) range. The proper range is [0, nproc-1].